### PR TITLE
Issue #46: Fix to correct namespace for CI/CD pipeline unit test failure

### DIFF
--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -22,7 +22,7 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-namespace tinymce_tiny_mce_wiris\privacy;
+namespace tiny_wiris\privacy;
 
 /**
  * Privacy Subsystem for MathType TinyMCE plugin implementing null_provider.


### PR DESCRIPTION
## Description
Hi team, this change was not merged into the main branch a couple months back. 

I renamed the namespace in provider.php to fix the unit test failure occurring.

Unit test error message:
```
There was 1 failure:
1) core_privacy_privacy_provider_test::test_all_providers_compliant with data set “tiny_wiris” ('tiny_wiris', 'tiny_wiris\privacy\provider').
Failed asserting that false is true.
```
- **Related GitHub Issue:** Closes #46, also related to #16

## Type of Change

- [X] Chore (non-breaking change that doesn't add any functionality)

## Checklist
- [X] My changes generate no new warnings or errors
- [X] New and existing unit tests pass locally with my changes

## How should be tested? (Manual or Automated Tests)
1. Deploy local Moodle instance (I'm testing with Moodle 4.5)
2. Initialize PHP Unit testing environment
3. Run `vendor/bin/phpunit privacy/tests/privacy/provider_test.php`
4. See the error above
5. Checkout to the feature branch `main-issue16`
6. Re-run the provider test
7. See the test passes
