### PR TITLE
fix: Moodle minimum version

### DIFF
--- a/version.php
+++ b/version.php
@@ -28,7 +28,7 @@ defined('MOODLE_INTERNAL') || die();
 
 $plugin->version = 2025061000;
 $plugin->release = '8.9.2';
-$plugin->requires = 2012120300;
+$plugin->requires = 2022112821.00;
 $plugin->component = 'tiny_wiris';
 $plugin->dependencies = ['filter_wiris' => 2025061000];
 $plugin->maturity = MATURITY_STABLE;


### PR DESCRIPTION
## Description

Update minimum version of Moodle compatibility to `4.1`.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] New and existing unit tests pass locally with my changes

## How should be tested?

Check the first release date of Moodle 4.1 (28 October 2022) and validate the number is correct. I took it from the Moodle 4.1 version file.
