### PR TITLE
fix: Tiny plugin naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ![MathType](./pix/logo-mathtype.png) MathType Moodle plugin for TinyMCE by WIRIS
 
-[![Moodle Plugin CI](https://github.com/wiris/moodle-tinymce_tiny_mce_wiris/actions/workflows/moodle-ci.yml/badge.svg)](https://github.com/wiris/moodle-tinymce_tiny_mce_wiris/actions/workflows/moodle-ci.yml)
+[![Moodle Plugin CI](https://github.com/wiris/moodle-tiny_wiris/actions/workflows/moodle-ci.yml/badge.svg)](https://github.com/wiris/moodle-tiny_wiris/actions/workflows/moodle-ci.yml)
 
 This repository contains the MathType TinyMCE plugin for Moodle versions later than 4.2, which integrates WIRIS tools to enable users to type and handwrite mathematical notation in Moodle with MathType for TinyMCE editor.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # ![MathType](../pix/logo-mathtype.png) MathType Moodle plugin for TinyMCE by WIRIS
 
-[![Moodle Plugin CI](https://github.com/wiris/moodle-tinymce_tiny_mce_wiris/actions/workflows/moodle-ci.yml/badge.svg)](https://github.com/wiris/moodle-tinymce_tiny_mce_wiris/actions/workflows/moodle-ci.yml)
+[![Moodle Plugin CI](https://github.com/wiris/moodle-tiny_wiris/actions/workflows/moodle-ci.yml/badge.svg)](https://github.com/wiris/moodle-tiny_wiris/actions/workflows/moodle-ci.yml)
 
 This repository contains the MathType TinyMCE plugin for Moodle versions later than 4.2, which integrates WIRIS tools to enable users to type and handwrite mathematical notation in Moodle with MathType for TinyMCE editor.
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "moodle-tiny_wiris",
   "version": "8.2.2",
   "description": "Type and handwrite mathematical notation in Moodle with MathType for TinyMCE Editor",
-  "homepage": "https://moodle.org/plugins/tinymce_tiny_mce_wiris",
+  "homepage": "https://moodle.org/plugins/tiny_wiris",
   "private": true,
   "scripts": {
     "preupdate-mathtype": "npx del js/plugin.min.js",


### PR DESCRIPTION
## Description

Some places in the projecthave the old plugin naming.

- **Related Kanbanize Card:** No KB card related/needed for this