### PR TITLE
test: change order of installation for quizzes since it failed in main

### DIFF
--- a/.github/workflows/moodle-ci.yml
+++ b/.github/workflows/moodle-ci.yml
@@ -209,17 +209,18 @@ jobs:
           moodle-plugin-ci add-plugin --branch main wiris/moodle-atto_wiris
 
       # 5. Install Wiris Quizzes plugin.
+      - name: Add Wiris Quizzes plugin using the v4.14.0 tag
+        id: add-quizzes-legacy
+        if: ${{ contains(fromJson('["MOODLE_39_STABLE", "MOODLE_311_STABLE", "MOODLE_400_STABLE", "MOODLE_401_STABLE", "MOODLE_402_STABLE", "MOODLE_403_STABLE", "MOODLE_404_STABLE"]'), matrix.moodle_branch) && steps.install-plugin-quizzes.outcome != 'success' }}
+        run: |
+          moodle-plugin-ci add-plugin --branch v4.14.0 wiris/moodle-qtype_wq
+
       - name: Add Wiris Quizzes plugin
         id: install-plugin-quizzes
         if: ${{ always() }}
         continue-on-error: true
         run: |
           moodle-plugin-ci add-plugin --branch ${{ env.BRANCH_NAME }} wiris/moodle-qtype_wq
-      - name: Add Wiris Quizzes plugin using the v4.14.0 tag
-        id: add-quizzes-legacy
-        if: ${{ contains(fromJson('["MOODLE_401_STABLE", "MOODLE_402_STABLE", "MOODLE_403_STABLE", "MOODLE_404_STABLE"]'), matrix.moodle_branch) && steps.install-plugin-quizzes.outcome != 'success' }}
-        run: |
-          moodle-plugin-ci add-plugin --branch v4.14.0 wiris/moodle-qtype_wq
 
       - name: Add Wiris Quizzes plugin using the main branch
         if: ${{ steps.add-quizzes-legacy.conclusion == 'skipped' && steps.install-plugin-quizzes.outcome != 'success' }}


### PR DESCRIPTION
## Description
Recently wq has changed the minimum required version of moodle for the wq thus breaking new instalations off the plugin on older Moodle versions.

The work was done in https://github.com/wiris/moodle-tiny_wiris/pull/61 but it was not working after merge (due to branch_name handeling) 

Related Kanbanize Card: [Link to KB-66484](https://wiris.kanbanize.com/ctrl_board/2/cards/66484/details/)